### PR TITLE
Disable interactive frontend during apt-get install.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 MAINTAINER John Fink <john.fink@gmail.com>
 RUN apt-get update
 RUN apt-get -y upgrade
-RUN apt-get -y install mysql-client mysql-server apache2 libapache2-mod-php5 pwgen python-setuptools vim-tiny php5-mysql
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install mysql-client mysql-server apache2 libapache2-mod-php5 pwgen python-setuptools vim-tiny php5-mysql
 RUN easy_install supervisor
 ADD ./start.sh /start.sh
 ADD ./foreground.sh /etc/apache2/foreground.sh


### PR DESCRIPTION
- Makes sure apt does not ask for MySQL root password.
