### PR TITLE
Remove apt-get upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:latest
 MAINTAINER John Fink <john.fink@gmail.com>
 RUN apt-get update # Thu Nov  7 22:40:44 EST 2013
-RUN apt-get -y upgrade
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install mysql-client mysql-server apache2 libapache2-mod-php5 pwgen python-setuptools vim-tiny php5-mysql
 RUN easy_install supervisor
 ADD ./start.sh /start.sh


### PR DESCRIPTION
Currently upgrade breaks the container build. Upgrading is 
unrecommended inside a container, as there is no init system and 
some packages have to be held back. 

To see the official issue: https://github.com/dotcloud/docker/issues/1724
To see workarounds: https://github.com/racker/docker-ubuntu-with-updates/blob/master/precise/Dockerfile
